### PR TITLE
plan(011): auth/cli_login progress streaming

### DIFF
--- a/planner/progress.md
+++ b/planner/progress.md
@@ -148,3 +148,16 @@
 • next:
     - extend login flow to surface progress updates and capture stderr for UI (RAT-LWS-REQ-094)
     - wire multi-agent launcher registry with cached credentials
+§ PLAN 011 — auth/cli_login progress streaming
+[ ] 011 — auth/cli_login progress streaming
+• acceptance: Stream CLI stderr to CT-WEB as progress notifications and emit completion once the login CLI exits.
+• prompts: [prompts/011_test.md](./prompts/011_test.md), [prompts/011_code.md](./prompts/011_code.md)
+• status: planned
+• notes:
+    - context: src/lib.rs, tests/bridge_handshake.rs
+    - js: not-run
+    - rust: not-run
+    - follow-ups: ensure audit logging of auth outcomes per RAT-LWS-REQ-094
+• next:
+    - Extend auth/cli_login to surface provider URLs via AWP start endpoint (RAT-LWS-REQ-208)
+    - Begin terminal execution permission flow (RAT-LWS-REQ-062)

--- a/planner/prompts/011_code.md
+++ b/planner/prompts/011_code.md
@@ -1,0 +1,40 @@
+Title: Step 011: Make tests pass for auth/cli_login progress streaming
+
+Context (read-only inputs):
+• Spec: planner/spec.md
+• Human hints: planner/human.md
+• Progress: planner/progress.md
+• New failing tests from: planner/prompts/011_test.md
+
+Acceptance (must satisfy):
+• Invoking `auth/cli_login` must immediately return `{status:"started"}` but also begin streaming CLI stderr output to CT-WEB via JSON-RPC notifications while the CLI runs.
+• Each stderr line is forwarded as an `auth/cli_login/progress` notification with a `message` string.
+• When the CLI process exits, the bridge emits a final `auth/cli_login/complete` notification containing the integer `exitCode`.
+• The CLI continues to launch via the existing resolution rules without blocking for process completion.
+
+Plan (you follow this order):
+1. GREEN — Implement the smallest change touching 1–3 files max to pass the new tests.
+2. RE-RUN TESTS — pnpm vitest --run && cargo test
+3. REFACTOR — Improve clarity/structure without changing behavior.
+4. LINT/FORMAT — cargo clippy --fix -q && cargo fmt && pnpm lint --fix && pnpm format
+5. FINAL TEST — pnpm vitest --run && cargo test must be fully green.
+
+Notes & logging (append-only):
+• Document implementation details, command outputs, and evidence in planner/notes/011_code.md using `§ CODE` blocks with timestamps.
+• Create the notes file if it does not exist; otherwise append new blocks without editing earlier content.
+• Reference any follow-up tasks or regressions discovered during the step.
+
+Constraints:
+• Do not edit tests unless they are objectively incorrect; if so, fix them minimally and add a note in planner/progress.md under this step.
+• Prefer clear, local changes over rewrites. Avoid renames unless essential.
+
+Commit message (format exactly):
+
+step(011): auth/cli_login progress streaming — green
+
+- tests: <list the test names that were failing>
+- touched: <files>
+- acceptance: <1 line>
+
+Exit condition:
+• All tests pass; lints/format pass; acceptance demonstrably true.

--- a/planner/prompts/011_test.md
+++ b/planner/prompts/011_test.md
@@ -1,0 +1,41 @@
+Title: Step 011: Write failing tests for auth/cli_login progress streaming
+
+Context (read-only inputs):
+• Spec: planner/spec.md (do not edit)
+• Human hints: planner/human.md (follow constraints)
+• Progress checklist: planner/progress.md (current step)
+
+Acceptance (authoritative for this step):
+• Invoking `auth/cli_login` must immediately return `{status:"started"}` but also begin streaming CLI stderr output to CT-WEB via JSON-RPC notifications while the CLI runs.
+• Each stderr line is forwarded as an `auth/cli_login/progress` notification with a `message` string.
+• When the CLI process exits, the bridge emits a final `auth/cli_login/complete` notification containing the integer `exitCode`.
+• The CLI continues to launch via the existing resolution rules without blocking for process completion.
+
+Scope & files:
+• Target area: tests/bridge_handshake.rs
+• You may create/modify only test files and light test scaffolding.
+• SolidJS: co-located tests *.test.tsx (Vitest + Testing Library).
+• Rust: unit tests beside code (mod tests {}) or tests/{name}.rs for integration.
+
+What to deliver:
+1. Minimal RED tests that fail against current code.
+2. Tests must pin observable behavior (no over-mocking; avoid brittle implementation details).
+3. For UI: prefer Testing Library queries of accessible roles/labels; if snapshots are needed, keep them tiny and stable.
+
+Notes & logging (append-only):
+• Append observations, decisions, and evidence to planner/notes/011_test.md using `§ TEST` blocks with timestamps.
+• Include the commands you ran, failing output snippets, and links to any generated artifacts.
+• Create the file if missing; otherwise append without altering earlier sections.
+
+Commands you will run:
+
+pnpm vitest --run
+cargo test
+
+Constraints:
+• Do not change application code.
+• Keep test names descriptive (<module>: <behavior>).
+• If you must introduce test utilities, put them in tests/utils/ (Rust) or test/utils/ (JS) with the smallest viable footprint.
+
+Exit condition:
+• You leave the repo in a state where pnpm vitest --run and/or cargo test fail due to the new tests.


### PR DESCRIPTION
## Summary
- log PLAN 011 for streaming auth/cli_login progress notifications and completion events in the progress tracker
- add matching test-writer and code-solver prompts covering progress and completion notifications now numbered 011

## Testing
- not run (planning-only change)

------
https://chatgpt.com/codex/tasks/task_e_68cca25a0bd08331a3c04dde71cc935c