### PR TITLE
plan(012): permission policy persistence renumber

### DIFF
--- a/planner/progress.md
+++ b/planner/progress.md
@@ -148,3 +148,17 @@
 • next:
     - extend login flow to surface progress updates and capture stderr for UI (RAT-LWS-REQ-094)
     - wire multi-agent launcher registry with cached credentials
+§ PLAN 012 — permission policy persistence
+[ ] 012 — permission policy persistence
+• acceptance: Persist allow/reject always decisions for fs/write_text_file so restarts reuse them while uncached paths still prompt.
+• prompts: [prompts/012_test.md](./prompts/012_test.md), [prompts/012_code.md](./prompts/012_code.md)
+• status: planned
+• notes:
+    - context: src/lib.rs, tests/bridge_handshake.rs
+    - js: not-run (SolidJS untouched)
+    - rust: pending (new tests expected to fail)
+    - follow-ups: expand policy store to cover other tool kinds and add audit logging (RAT-LWS-REQ-094)
+• next:
+    - RAT-LWS-REQ-094 — record permission prompts/outcomes with redaction
+    - RAT-LWS-REQ-062 — gate terminal/start with permission prompts
+    - RAT-LWS-REQ-205 — design AWP callback capture scaffolding

--- a/planner/prompts/012_code.md
+++ b/planner/prompts/012_code.md
@@ -1,0 +1,40 @@
+Title: Step 012: Make tests pass for permission policy persistence
+
+Context (read-only inputs):
+• Spec: planner/spec.md
+• Human hints: planner/human.md
+• Progress: planner/progress.md
+• New failing tests from: planner/prompts/012_test.md
+
+Acceptance (must satisfy):
+• Permission cache decisions for `fs/write_text_file` MUST persist across bridge restarts.
+• When a path is approved with `allow_always`, subsequent writes after restarting the bridge (with the same policy store path) proceed without a new permission request.
+• When a path is marked `reject_always`, the bridge must reject subsequent writes immediately without contacting the agent.
+• Paths lacking entries continue to request permission.
+
+Plan (you follow this order):
+1. GREEN — Implement the smallest change touching 1–3 files max to pass the new tests.
+2. RE-RUN TESTS — pnpm vitest --run && cargo test
+3. REFACTOR — Improve clarity/structure without changing behavior.
+4. LINT/FORMAT — cargo clippy --fix -q && cargo fmt && pnpm lint --fix && pnpm format
+5. FINAL TEST — pnpm vitest --run && cargo test must be fully green.
+
+Notes & logging (append-only):
+• Document implementation details, command outputs, and evidence in planner/notes/012_code.md using `§ CODE` blocks with timestamps.
+• Create the notes file if it does not exist; otherwise append new blocks without editing earlier content.
+• Reference any follow-up tasks or regressions discovered during the step.
+
+Constraints:
+• Do not edit tests unless they are objectively incorrect; if so, fix them minimally and add a note in planner/progress.md under this step.
+• Prefer clear, local changes over rewrites. Avoid renames unless essential.
+
+Commit message (format exactly):
+
+step(012): permission policy persistence — green
+
+- tests: <list the test names that were failing>
+- touched: <files>
+- acceptance: Persist allow/reject always decisions across bridge restarts
+
+Exit condition:
+• All tests pass; lints/format pass; acceptance demonstrably true.

--- a/planner/prompts/012_test.md
+++ b/planner/prompts/012_test.md
@@ -1,0 +1,41 @@
+Title: Step 012: Write failing tests for permission policy persistence
+
+Context (read-only inputs):
+• Spec: planner/spec.md (do not edit)
+• Human hints: planner/human.md (follow constraints)
+• Progress checklist: planner/progress.md (current step)
+
+Acceptance (authoritative for this step):
+• Permission cache decisions for `fs/write_text_file` MUST persist across bridge restarts.
+• When a path is approved with `allow_always`, subsequent writes after restarting the bridge (with the same policy store path) proceed without a new permission request.
+• When a path is marked `reject_always`, the bridge must reject subsequent writes immediately without contacting the agent.
+• Paths lacking entries continue to request permission.
+
+Scope & files:
+• Target area: tests/bridge_handshake.rs (BridgeHarness utilities + fs/write_text_file integration cases)
+• You may create/modify only test files and light test scaffolding.
+• SolidJS: co-located tests *.test.tsx (Vitest + Testing Library).
+• Rust: unit tests beside code (mod tests {}) or tests/{name}.rs for integration.
+
+What to deliver:
+1. Minimal RED tests that fail against current code.
+2. Tests must pin observable behavior (no over-mocking; avoid brittle implementation details).
+3. For UI: prefer Testing Library queries of accessible roles/labels; if snapshots are needed, keep them tiny and stable.
+
+Notes & logging (append-only):
+• Append observations, decisions, and evidence to planner/notes/012_test.md using `§ TEST` blocks with timestamps.
+• Include the commands you ran, failing output snippets, and links to any generated artifacts.
+• Create the file if missing; otherwise append without altering earlier sections.
+
+Commands you will run:
+
+pnpm vitest --run
+cargo test
+
+Constraints:
+• Do not change application code.
+• Keep test names descriptive (<module>: <behavior>).
+• If you must introduce test utilities, put them in tests/utils/ (Rust) or test/utils/ (JS) with the smallest viable footprint.
+
+Exit condition:
+• You leave the repo in a state where pnpm vitest --run and/or cargo test fail due to the new tests.


### PR DESCRIPTION
## Summary
- renumber the permission policy persistence plan entry to step 012 and update prompt links
- update the associated test and code prompt titles, note paths, and commit message template to use step 012

## Testing
- not run (docs-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cca26ab5108331951a89379a1d7c9b