### PR TITLE
plan(013): renumber audit trail step

### DIFF
--- a/planner/progress.md
+++ b/planner/progress.md
@@ -148,3 +148,38 @@
 • next:
     - extend login flow to surface progress updates and capture stderr for UI (RAT-LWS-REQ-094)
     - wire multi-agent launcher registry with cached credentials
+§ PLAN 010 — fs/write_text_file permission audit trail
+[ ] 010 — fs/write_text_file permission audit trail
+• acceptance: Log redacted prompt/outcome entries for fs/write_text_file permissions with canonical-path hashing.
+• prompts: [prompts/010_test.md](./prompts/010_test.md), [prompts/010_code.md](./prompts/010_code.md)
+• status: planned
+• notes:
+    - context: src/lib.rs, tests/bridge_handshake.rs, Cargo.toml (dev-deps for hashing/tempfiles)
+    - js: not-run
+    - rust: not-run
+    - follow-ups: consider central audit logger for terminal + auth events; persist policy registry to disk
+• next:
+    - expand audit coverage to terminal approvals per RAT-LWS-REQ-062/094
+    - persist permission policies and audit logs per RAT-LWS-REQ-092
+    - surface audit summaries to CT-WEB diagnostic view (spec RAT-LWS-REQ-131)
+§ UPDATE 010 — renumbered to 013
+• status: planned
+• notes:
+    - step renumbered to 013 per latest instructions; see PLAN 013 for active prompts.
+• js: not-run
+• rust: not-run
+
+§ PLAN 013 — fs/write_text_file permission audit trail
+[ ] 013 — fs/write_text_file permission audit trail
+• acceptance: Log redacted prompt/outcome entries for fs/write_text_file permissions with canonical-path hashing.
+• prompts: [prompts/013_test.md](./prompts/013_test.md), [prompts/013_code.md](./prompts/013_code.md)
+• status: planned
+• notes:
+    - context: src/lib.rs, tests/bridge_handshake.rs, Cargo.toml (dev-deps for hashing/tempfiles)
+    - js: not-run
+    - rust: not-run
+    - follow-ups: consider central audit logger for terminal + auth events; persist policy registry to disk
+• next:
+    - expand audit coverage to terminal approvals per RAT-LWS-REQ-062/094
+    - persist permission policies and audit logs per RAT-LWS-REQ-092
+    - surface audit summaries to CT-WEB diagnostic view (spec RAT-LWS-REQ-131)

--- a/planner/prompts/013_code.md
+++ b/planner/prompts/013_code.md
@@ -1,0 +1,41 @@
+Purpose: write the smallest diffs that make the 013 tests pass, then refactor safely. Never modify planner/spec.md.
+
+Title: Step 013: Make tests pass for fs/write_text_file permission audit trail
+
+Context (read-only inputs):
+- Spec: planner/spec.md
+- Human hints: planner/human.md
+- Progress: planner/progress.md
+- New failing tests from: planner/prompts/013_test.md
+
+Acceptance (must satisfy):
+- Whenever the bridge requests permission for `fs/write_text_file`, it must append an audit entry to a configured log file describing the prompt without recording the file contents.
+- After the agent replies, a second audit entry must capture the resulting decision (selected option or cancellation) alongside the session id while keeping sensitive data redacted.
+- Log entries MUST provide a stable hash derived from the canonical path so that repeated prompts for the same file can be correlated without exposing the raw path.
+
+Plan (you follow this order):
+1. GREEN — Implement the smallest change touching 1–3 files max to pass the new tests.
+2. RE-RUN TESTS — pnpm vitest --run && cargo test
+3. REFACTOR — Improve clarity/structure without changing behavior.
+4. LINT/FORMAT — cargo clippy --fix -q && cargo fmt && pnpm lint --fix && pnpm format
+5. FINAL TEST — pnpm vitest --run && cargo test must be fully green.
+
+Notes & logging (append-only):
+- Document implementation details, command outputs, and evidence in planner/notes/013_code.md using `§ CODE` blocks with timestamps.
+- Create the notes file if it does not exist; otherwise append new blocks without editing earlier content.
+- Reference any follow-up tasks or regressions discovered during the step.
+
+Constraints:
+- Do not edit tests unless they are objectively incorrect; if so, fix them minimally and add a note in planner/progress.md under this step.
+- Prefer clear, local changes over rewrites. Avoid renames unless essential.
+
+Commit message (format exactly):
+
+step(013): fs/write_text_file permission audit trail — green
+
+- tests: <list the test names that were failing>
+- touched: <files>
+- acceptance: <1 line>
+
+Exit condition:
+- All tests pass; lints/format pass; acceptance demonstrably true.

--- a/planner/prompts/013_test.md
+++ b/planner/prompts/013_test.md
@@ -1,0 +1,42 @@
+Purpose: produce failing tests first, nothing else. Keep the working set minimal. Never modify planner/spec.md.
+
+Title: Step 013: Write failing tests for fs/write_text_file permission audit trail
+
+Context (read-only inputs):
+- Spec: planner/spec.md (do not edit)
+- Human hints: planner/human.md (follow constraints)
+- Progress checklist: planner/progress.md (current step)
+
+Acceptance (authoritative for this step):
+- Whenever the bridge requests permission for `fs/write_text_file`, it must append an audit entry to a configured log file describing the prompt without recording the file contents.
+- After the agent replies, a second audit entry must capture the resulting decision (selected option or cancellation) alongside the session id while keeping sensitive data redacted.
+- Log entries MUST provide a stable hash derived from the canonical path so that repeated prompts for the same file can be correlated without exposing the raw path.
+
+Scope & files:
+- Target area: tests/bridge_handshake.rs (integration tests driving permission flows)
+- You may create/modify only test files and light test scaffolding under tests/.
+- Rust: integration tests under tests/, using existing BridgeHarness utilities; update test-only helpers as needed.
+
+What to deliver:
+1. Add a new integration test that drives a `fs/write_text_file` permission approval and asserts two audit log entries are written: one for the prompt and one for the outcome.
+2. The test should verify the log entries include the session id, tool name, a stable hash for the canonical path, and that the raw file content string never appears in the log file.
+3. Extend the test harness minimally (e.g., allow configuring an audit log path) so the test can read and assert against a temporary log file without affecting other suites.
+
+Notes & logging (append-only):
+- Append observations, decisions, and evidence to planner/notes/013_test.md using `§ TEST` blocks with timestamps.
+- Include the commands you ran, failing output snippets, and links to any generated artifacts.
+- Create the file if missing; otherwise append without altering earlier sections.
+
+Commands you will run:
+```
+pnpm vitest --run
+cargo test
+```
+
+Constraints:
+- Do not change application code.
+- Keep test names descriptive (<module>: <behavior>).
+- Maintain existing filesystem isolation by cleaning up any files under the project root sandbox.
+
+Exit condition:
+- You leave the repo in a state where pnpm vitest --run and/or cargo test fail because the new audit trail test asserts behavior the bridge has not implemented yet.


### PR DESCRIPTION
## Summary
- renumber the fs/write_text_file permission audit trail planning step to 013 in the prompts and progress log
- update associated planner notes references and commit message template to match the new step number

## Testing
- not run (documentation-only updates)


------
https://chatgpt.com/codex/tasks/task_e_68cca267ade883318fff7d56bd994dc3