### PR TITLE
plan: renumber step 014 prompts

### DIFF
--- a/planner/progress.md
+++ b/planner/progress.md
@@ -148,3 +148,16 @@
 • next:
     - extend login flow to surface progress updates and capture stderr for UI (RAT-LWS-REQ-094)
     - wire multi-agent launcher registry with cached credentials
+§ PLAN 014 — permission policy persistence across restarts
+[ ] 014 — permission policy persistence across restarts
+• acceptance: Persist fs/write_text_file allow_always decisions to a bridge policy store and reload them after restart so the next write skips permission prompts.
+• prompts: [prompts/014_test.md](./prompts/014_test.md), [prompts/014_code.md](./prompts/014_code.md)
+• status: planned
+• notes:
+    - context: src/lib.rs, tests/bridge_handshake.rs
+    - js: not-run
+    - rust: not-run
+    - follow-ups: ensure reject_always persistence and broader policy registry coverage
+• next:
+    - RAT-LWS-REQ-092: persist reject_always decisions across bridge restarts
+    - RAT-LWS-REQ-062/063: implement terminal execution permission gating and output streaming

--- a/planner/prompts/014_code.md
+++ b/planner/prompts/014_code.md
@@ -1,0 +1,37 @@
+Title: Step 014: Make tests pass for persisted fs/write_text_file policies
+
+Context (read-only inputs):
+• Spec: planner/spec.md
+• Human hints: planner/human.md
+• Progress: planner/progress.md
+• New failing tests from: planner/prompts/014_test.md
+
+Acceptance (must satisfy):
+• When fs/write_text_file is approved with the `allow_always` option, the bridge must persist that decision and reload it after a restart so the very next write to the same canonical path succeeds without triggering another permission request. The policy store location must be configurable so tests can point it at a temporary file, and the bridge should skip touching the agent during the second write. The test must assert both the persisted success response and that the agent observed no additional `request_permission` calls on the second bridge run.
+
+Plan (you follow this order):
+1. GREEN — Implement the smallest change touching 1–3 files max to pass the new tests.
+2. RE-RUN TESTS — pnpm vitest --run && cargo test
+3. REFACTOR — Improve clarity/structure without changing behavior.
+4. LINT/FORMAT — cargo clippy --fix -q && cargo fmt && pnpm lint --fix && pnpm format
+5. FINAL TEST — pnpm vitest --run && cargo test must be fully green.
+
+Notes & logging (append-only):
+• Document implementation details, command outputs, and evidence in planner/notes/014_code.md using `§ CODE` blocks with timestamps.
+• Create the notes file if it does not exist; otherwise append new blocks without editing earlier content.
+• Reference any follow-up tasks or regressions discovered during the step.
+
+Constraints:
+• Do not edit tests unless they are objectively incorrect; if so, fix them minimally and add a note in planner/progress.md under this step.
+• Prefer clear, local changes over rewrites. Avoid renames unless essential.
+
+Commit message (format exactly):
+
+step(014): persisted fs/write policies — green
+
+- tests: <list the test names that were failing>
+- touched: <files>
+- acceptance: <1 line>
+
+Exit condition:
+• All tests pass; lints/format pass; acceptance demonstrably true.

--- a/planner/prompts/014_test.md
+++ b/planner/prompts/014_test.md
@@ -1,0 +1,38 @@
+Title: Step 014: Write failing tests for persisted fs/write_text_file policies
+
+Context (read-only inputs):
+• Spec: planner/spec.md (do not edit)
+• Human hints: planner/human.md (follow constraints)
+• Progress checklist: planner/progress.md (current step)
+
+Acceptance (authoritative for this step):
+• When fs/write_text_file is approved with the `allow_always` option, the bridge must persist that decision and reload it after a restart so the very next write to the same canonical path succeeds without triggering another permission request. The policy store location must be configurable so tests can point it at a temporary file, and the bridge should skip touching the agent during the second write. The test must assert both the persisted success response and that the agent observed no additional `request_permission` calls on the second bridge run.
+
+Scope & files:
+• Target area: tests/bridge_handshake.rs
+• You may create/modify only test files and light test scaffolding.
+• SolidJS: co-located tests *.test.tsx (Vitest + Testing Library).
+• Rust: unit tests beside code (mod tests {}) or tests/{name}.rs for integration.
+
+What to deliver:
+1. Minimal RED tests that fail against current code.
+2. Tests must pin observable behavior (no over-mocking; avoid brittle implementation details).
+3. For UI: prefer Testing Library queries of accessible roles/labels; if snapshots are needed, keep them tiny and stable.
+
+Notes & logging (append-only):
+• Append observations, decisions, and evidence to planner/notes/014_test.md using `§ TEST` blocks with timestamps.
+• Include the commands you ran, failing output snippets, and links to any generated artifacts.
+• Create the file if missing; otherwise append without altering earlier sections.
+
+Commands you will run:
+
+pnpm vitest --run
+cargo test
+
+Constraints:
+• Do not change application code.
+• Keep test names descriptive (<module>: <behavior>).
+• If you must introduce test utilities, put them in tests/utils/ (Rust) or test/utils/ (JS) with the smallest viable footprint.
+
+Exit condition:
+• You leave the repo in a state where pnpm vitest --run and/or cargo test fail due to the new tests.


### PR DESCRIPTION
## Summary
- update planner progress entry to refer to step 014 instead of 010
- rename the paired code and test prompts to 014 and adjust their internal references accordingly

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cca25f72908331ad53d5ca2163900e