### PR TITLE
plan(015): rename truncation step

### DIFF
--- a/planner/progress.md
+++ b/planner/progress.md
@@ -148,3 +148,16 @@
 • next:
     - extend login flow to surface progress updates and capture stderr for UI (RAT-LWS-REQ-094)
     - wire multi-agent launcher registry with cached credentials
+§ PLAN 015 — fs/read_text_file truncation meta
+[ ] 015 — fs/read_text_file truncation meta
+• acceptance: Flag truncated fs/read_text_file results by setting `_meta.truncated` when a line_limit trims content.
+• prompts: [prompts/015_test.md](./prompts/015_test.md), [prompts/015_code.md](./prompts/015_code.md)
+• status: planned
+• notes:
+    - context: src/lib.rs, tests/bridge_handshake.rs
+    - js: not-run
+    - rust: not-run
+    - follow-ups: persist permission cache per RAT-LWS-REQ-092; surface auth CLI progress updates (RAT-LWS-REQ-094)
+• next:
+    - RAT-LWS-REQ-092: persist always-allow decisions across sessions
+    - RAT-LWS-REQ-094: emit auth/cli_login progress + stderr for UI streaming

--- a/planner/prompts/015_code.md
+++ b/planner/prompts/015_code.md
@@ -1,0 +1,39 @@
+Title: Step 015: Make tests pass for fs/read_text_file truncation meta
+
+Context (read-only inputs):
+• Spec: planner/spec.md
+• Human hints: planner/human.md
+• Progress: planner/progress.md
+• New failing tests from: planner/prompts/015_test.md
+
+Acceptance (must satisfy):
+• Flag truncated file reads in `fs/read_text_file` responses.
+• When a request supplies `line_limit` and the file has more content beyond the returned slice, include `_meta.truncated: true` in the JSON-RPC result.
+• When the requested range covers the full file contents, omit the truncated flag so callers know the read was complete.
+
+Plan (you follow this order):
+1. GREEN — Implement the smallest change touching 1–3 files max to pass the new tests.
+2. RE-RUN TESTS — pnpm vitest --run && cargo test
+3. REFACTOR — Improve clarity/structure without changing behavior.
+4. LINT/FORMAT — cargo clippy --fix -q && cargo fmt && pnpm lint --fix && pnpm format
+5. FINAL TEST — pnpm vitest --run && cargo test must be fully green.
+
+Notes & logging (append-only):
+• Document implementation details, command outputs, and evidence in planner/notes/015_code.md using `§ CODE` blocks with timestamps.
+• Create the notes file if it does not exist; otherwise append new blocks without editing earlier content.
+• Reference any follow-up tasks or regressions discovered during the step.
+
+Constraints:
+• Do not edit tests unless they are objectively incorrect; if so, fix them minimally and add a note in planner/progress.md under this step.
+• Prefer clear, local changes over rewrites. Avoid renames unless essential.
+
+Commit message (format exactly):
+
+step(015): fs/read_text_file truncation meta — green
+
+- tests: <list the test names that were failing>
+- touched: <files>
+- acceptance: <1 line>
+
+Exit condition:
+• All tests pass; lints/format pass; acceptance demonstrably true.

--- a/planner/prompts/015_test.md
+++ b/planner/prompts/015_test.md
@@ -1,0 +1,40 @@
+Title: Step 015: Write failing tests for fs/read_text_file truncation meta
+
+Context (read-only inputs):
+• Spec: planner/spec.md (do not edit)
+• Human hints: planner/human.md (follow constraints)
+• Progress checklist: planner/progress.md (current step)
+
+Acceptance (authoritative for this step):
+• Flag truncated file reads in `fs/read_text_file` responses.
+• When a request supplies `line_limit` and the file has more content beyond the returned slice, include `_meta.truncated: true` in the JSON-RPC result.
+• When the requested range covers the full file contents, omit the truncated flag so callers know the read was complete.
+
+Scope & files:
+• Target area: tests/bridge_handshake.rs
+• You may create/modify only test files and light test scaffolding.
+• SolidJS: co-located tests *.test.tsx (Vitest + Testing Library).
+• Rust: unit tests beside code (mod tests {}) or tests/{name}.rs for integration.
+
+What to deliver:
+1. Minimal RED tests that fail against current code.
+2. Tests must pin observable behavior (no over-mocking; avoid brittle implementation details).
+3. For UI: prefer Testing Library queries of accessible roles/labels; if snapshots are needed, keep them tiny and stable.
+
+Notes & logging (append-only):
+• Append observations, decisions, and evidence to planner/notes/015_test.md using `§ TEST` blocks with timestamps.
+• Include the commands you ran, failing output snippets, and links to any generated artifacts.
+• Create the file if missing; otherwise append without altering earlier sections.
+
+Commands you will run:
+
+pnpm vitest --run
+cargo test
+
+Constraints:
+• Do not change application code.
+• Keep test names descriptive (<module>: <behavior>).
+• If you must introduce test utilities, put them in tests/utils/ (Rust) or test/utils/ (JS) with the smallest viable footprint.
+
+Exit condition:
+• You leave the repo in a state where pnpm vitest --run and/or cargo test fail due to the new tests.


### PR DESCRIPTION
## Summary
- retitle the truncation metadata plan block in planner/progress.md from step 010 to step 015
- update the paired planner prompts to use the 015 step numbering and notes paths

## Testing
- not run (planning-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cca0e1b2848331a2ea9238e1902273