### PR TITLE
plan(017): renumber sandbox escape guard step

### DIFF
--- a/planner/progress.md
+++ b/planner/progress.md
@@ -148,3 +148,16 @@
 • next:
     - extend login flow to surface progress updates and capture stderr for UI (RAT-LWS-REQ-094)
     - wire multi-agent launcher registry with cached credentials
+§ PLAN 017 — fs/read_text_file sandbox escape guard
+[ ] 017 — fs/read_text_file sandbox escape guard
+• acceptance: reject fs/read_text_file paths that resolve outside project root without invoking permission flow (RAT-LWS-REQ-044)
+• prompts: [prompts/017_test.md](./prompts/017_test.md), [prompts/017_code.md](./prompts/017_code.md)
+• status: planned
+• notes:
+    - context: tests/bridge_handshake.rs new regression; src/lib.rs path sandboxing helpers
+    - js: not-run
+    - rust: not-run
+    - follow-ups: extend same guard to other tool namespaces (terminal, auth proxy paths)
+• next:
+    - enforce project-root sandbox for fs/write_text_file relative `../` escapes (RAT-LWS-REQ-044)
+    - add terminal execution permission gating test per RAT-LWS-REQ-062/063

--- a/planner/prompts/017_code.md
+++ b/planner/prompts/017_code.md
@@ -1,0 +1,38 @@
+Title: Step 017: Make tests pass for fs/read_text_file project-root escape guard
+
+Context (read-only inputs):
+    • Spec: planner/spec.md
+    • Human hints: planner/human.md
+    • Progress: planner/progress.md
+    • New failing tests from: planner/prompts/017_test.md
+
+Acceptance (must satisfy):
+    • The bridge MUST reject fs/read_text_file requests whose path resolves outside the project root (e.g., an absolute /tmp path) before touching permission flows, responding with a JSON-RPC error instead of method-not-found.
+    • The rejection proves RAT-LWS-REQ-044 by showing the agent transport never sees a permission request when such an escape is attempted.
+
+Plan (you follow this order):
+    1. GREEN — Implement the smallest change touching 1–3 files max to pass the new tests.
+    2. RE-RUN TESTS — pnpm vitest --run && cargo test
+    3. REFACTOR — Improve clarity/structure without changing behavior.
+    4. LINT/FORMAT — cargo clippy --fix -q && cargo fmt && pnpm lint --fix && pnpm format
+    5. FINAL TEST — pnpm vitest --run && cargo test must be fully green.
+
+Notes & logging (append-only):
+    • Document implementation details, command outputs, and evidence in planner/notes/017_code.md using `§ CODE` blocks with timestamps.
+    • Create the notes file if it does not exist; otherwise append new blocks without editing earlier content.
+    • Reference any follow-up tasks or regressions discovered during the step.
+
+Constraints:
+    • Do not edit tests unless they are objectively incorrect; if so, fix them minimally and add a note in planner/progress.md under this step.
+    • Prefer clear, local changes over rewrites. Avoid renames unless essential.
+
+Commit message (format exactly):
+
+step(017): fs/read_text_file escape guard — green
+
+- tests: <list the test names that were failing>
+- touched: <files>
+- acceptance: <1 line>
+
+Exit condition:
+    • All tests pass; lints/format pass; acceptance demonstrably true.

--- a/planner/prompts/017_test.md
+++ b/planner/prompts/017_test.md
@@ -1,0 +1,39 @@
+Title: Step 017: Write failing tests for fs/read_text_file project-root escape guard
+
+Context (read-only inputs):
+    • Spec: planner/spec.md (do not edit)
+    • Human hints: planner/human.md (follow constraints)
+    • Progress checklist: planner/progress.md (current step)
+
+Acceptance (authoritative for this step):
+    • The bridge MUST reject fs/read_text_file requests whose path resolves outside the project root (e.g., an absolute /tmp path) before touching permission flows, responding with a JSON-RPC error instead of method-not-found.
+    • The rejection proves RAT-LWS-REQ-044 by showing the agent transport never sees a permission request when such an escape is attempted.
+
+Scope & files:
+    • Target area: tests/bridge_handshake.rs (new regression covering absolute-path escapes).
+    • You may create/modify only test files and light test scaffolding.
+    • SolidJS: co-located tests *.test.tsx (Vitest + Testing Library).
+    • Rust: unit tests beside code (mod tests {}) or tests/{name}.rs for integration.
+
+What to deliver:
+    1. Minimal RED tests that fail against current code.
+    2. Tests must pin observable behavior (no over-mocking; avoid brittle implementation details).
+    3. For UI: prefer Testing Library queries of accessible roles/labels; if snapshots are needed, keep them tiny and stable.
+
+Notes & logging (append-only):
+    • Append observations, decisions, and evidence to planner/notes/017_test.md using `§ TEST` blocks with timestamps.
+    • Include the commands you ran, failing output snippets, and links to any generated artifacts.
+    • Create the file if missing; otherwise append without altering earlier sections.
+
+Commands you will run:
+
+pnpm vitest --run
+cargo test
+
+Constraints:
+    • Do not change application code.
+    • Keep test names descriptive (<module>: <behavior>).
+    • If you must introduce test utilities, put them in tests/utils/ (Rust) or test/utils/ (JS) with the smallest viable footprint.
+
+Exit condition:
+    • You leave the repo in a state where pnpm vitest --run and/or cargo test fail due to the new tests.


### PR DESCRIPTION
## Summary
- update planner/progress.md to track the fs/read_text_file escape guard work under step 017
- rename the paired prompts to 017 and refresh their internal references

## Testing
- not run (planning-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cca25cc7c08331b3648141fa7e67aa